### PR TITLE
fix: Footer の余白を修正, article を createdAt でソート

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -7,7 +7,7 @@ import { colors } from '@src/styles/colors'
 
 export const Footer: VFC = () => {
   return (
-    <Box bg={colors.secondaryGray} as="footer" paddingBottom={2} paddingTop={12}>
+    <Box bg={colors.secondaryGray} as="footer" paddingBottom={4} paddingTop={12}>
       <Center flexDirection="column">
         <HStack spacing="20px">
           <GitHubIcon width={5} height={5} color={colors.lightGray} />

--- a/src/lib/articles.ts
+++ b/src/lib/articles.ts
@@ -17,8 +17,15 @@ const client = createClient({
   accessToken: process.env.CF_DELIVERY_ACCESS_TOKEN ?? '', // delivery API key for the space \
 })
 
-export const getArticles = async () => {
-  const { items } = await client.getEntries<IArticleFields>({ limit: 20 })
+export const getArticles = async (page = 1) => {
+  const limit = 12
+
+  //NOTE: https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/reverse-order
+  const { items } = await client.getEntries<IArticleFields>({
+    limit,
+    skip: (page - 1) * limit,
+    order: '-sys.createdAt',
+  })
 
   return items.map(({ sys, fields, metadata }) => ({
     id: sys.id,


### PR DESCRIPTION
## 実装内容
- Footer の 余白を修正

## 関連 Issue
#45 
#44 