### PR TITLE
feat: 環境ごとに取得する記事を切り替える

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,4 @@ yarn-error.log*
 
 build-storybook.log
 
-.env
+.env*

--- a/src/components/ArticleContent/ArticleContent.stories.tsx
+++ b/src/components/ArticleContent/ArticleContent.stories.tsx
@@ -27,35 +27,59 @@ const article = {
   date: '2022-04-03T13:45:10.439Z',
   tags: ['react'] as TagName[],
   markdown:
-    `# Heading1\n` +
-    `この定理に関して、私は真に驚くべき証明を見つけたが、この余白はそれを書くには狭すぎる。\n` +
-    `## Heading2\n` +
-    `この定理に関して、私は真に驚くべき証明を見つけたが、この余白はそれを書くには狭すぎる。\n` +
-    `### Heading3\n` +
-    `この定理に関して、私は真に驚くべき証明を見つけたが、この余白はそれを書くには狭すぎる。\n` +
-    `#### Heading4\n` +
-    `この定理に関して、私は真に驚くべき証明を見つけたが、この余白はそれを書くには狭すぎる。\n` +
-    `- list\n` +
-    `- list\n` +
-    `  - nested list\n` +
-    `1. ordered list\n` +
-    `2. ordered list\n` +
-    `3. ordered list\n` +
-    `\n` +
-    `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. \n` +
-    `この定理に関して、私は真に驚くべき証明を見つけたが、この余白はそれを書くには狭すぎる。\n` +
-    `\n` +
+    '# Heading1\n' +
+    'この定理に関して、私は真に驚くべき証明を見つけたが、この余白はそれを書くには狭すぎる。 :smile:\n' +
+    '\n' +
+    '## Heading2\n' +
+    'この定理に関して、私は真に驚くべき証明を見つけたが、この余白はそれを書くには狭すぎる。\n' +
+    '\n' +
+    '### Heading3\n' +
+    'この定理に関して、私は真に驚くべき証明を見つけたが、この余白はそれを書くには狭すぎる。\n' +
+    '\n' +
+    '#### Heading4\n' +
+    'この定理に関して、私は真に驚くべき証明を見つけたが、この余白はそれを書くには狭すぎる。\n' +
+    '\n' +
+    '- list\n' +
+    '- list\n' +
+    '  - nested list  \n' +
+    '\n' +
+    '1. ordered list\n' +
+    '2. ordered list\n' +
+    '3. ordered list\n' +
+    '\n' +
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. \n' +
+    '\n' +
+    'この定理に関して、私は真に驚くべき証明を見つけたが、この余白はそれを書くには狭すぎる。\n' +
+    '\n' +
     '`git pull`\n' +
-    '```ts\n' +
+    '\n' +
+    '```js:.storybook/main.js\n' +
     'module.exports = {\n' +
     "  stories: ['../**/*.stories.mdx', '../**/*.stories.@(js|jsx|ts|tsx)'],\n" +
     "  addons: ['@storybook/addon-links', '@storybook/addon-essentials'],\n" +
+    "  framework: '@storybook/react',\n" +
+    "  // unpins Storybook's dependence on Emotion 10 so that build can compile successfully\n" +
+    '  features: { emotionAlias: false },\n' +
+    '  webpackFinal: async (config, { configType }) => {\n' +
+    "    // `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'\n" +
+    '    // You can change the configuration based on that.\n' +
+    "    // 'PRODUCTION' is used when building the static version of storybook.\n" +
+    '\n' +
+    '    // https://github.com/polkadot-js/extension/issues/621#issuecomment-759341776\n' +
+    '    // framer-motion uses the .mjs notation and we need to include it so that webpack will\n' +
+    '    // transpile it for us correctly (enables using a CJS module inside an ESM).\n' +
+    '    config.module.rules.push({\n' +
+    '      test: /\\.mjs$/,\n' +
+    '      include: /node_modules/,\n' +
+    "      type: 'javascript/auto',\n" +
+    '    });\n' +
     '    // Return the altered config\n' +
     '    return config;\n' +
     '  },\n' +
     '};\n' +
     '```\n' +
-    'どちらは場合はなはだそんな所有者という点の他をしうます。単に将来に説明式もきっとその譴責なたいまでが及ぼすば行っましがも観念行っらしくまして、あいにくにもありなでしうです。学校によっまし訳もむくむく先刻へはなはだでしょならです。いよいよネルソンさんが見当支再び意味を云わなけれ個人こうした権力あなたか使用がに対するご相違うなだっまいから、その時間は私か町内絵に思わが、嘉納さんののを人間の私に実にお誤認とたべとそれ途を同使用で勧めようにどうにかご［＃「が行っないですば、できるだけひょろひょろ標榜を繰り返したばくれでのをなっでします。',
+    '\n' +
+    'どちらは場合はなはだそんな所有者という点の他をしうます。単に将来に説明式もきっとその譴責なたいまでが及ぼすば行っましがも観念行っらしくまして、あいにくにもありなでしうです。学校によっまし訳もむくむく先刻へはなはだでしょならです。いよいよネルソンさんが見当支再び意味を云わなけれ個人こうした権力あなたか使用がに対するご相違うなだっまいから、その時間は私か町内絵に思わが、嘉納さんののを人間の私に実にお誤認とたべとそれ途を同使用で勧めようにどうにかご［＃「が行っないですば、できるだけひょろひょろ標榜を繰り返したばくれでのをなっでします。\n',
 }
 
 export const Primary = Template.bind({})

--- a/src/lib/articles.ts
+++ b/src/lib/articles.ts
@@ -26,8 +26,6 @@ const devConfig = {
 
 const config = process.env.NODE_ENV === 'production' ? prodConfig : devConfig
 
-console.log('============================= CONFIG =============================')
-console.log(config)
 const client = createClient(config)
 
 const articlesPerPage = 12

--- a/src/lib/articles.ts
+++ b/src/lib/articles.ts
@@ -12,10 +12,22 @@ export type MetaData = {
 
 export type Article = MetaData & { markdown?: string }
 
-const client = createClient({
-  space: process.env.CF_SPACE_ID ?? '', // ID of a Compose-compatible space to be used \
-  accessToken: process.env.CF_DELIVERY_ACCESS_TOKEN ?? '', // delivery API key for the space \
-})
+const _config = {
+  space: process.env.CF_SPACE_ID ?? '',
+  accessToken: process.env.CF_ACCESS_TOKEN ?? '',
+}
+
+const config =
+  process.env.NODE_ENV === 'production'
+    ? _config
+    : {
+        ..._config,
+        // NOTE: preview の API を叩く場合は host を preview.contentful.com にする必要がある
+        //       https://www.contentful.com/developers/docs/references/content-preview-api/
+        host: 'preview.contentful.com',
+      }
+
+const client = createClient(config)
 
 const articlesPerPage = 12
 

--- a/src/lib/articles.ts
+++ b/src/lib/articles.ts
@@ -12,21 +12,22 @@ export type MetaData = {
 
 export type Article = MetaData & { markdown?: string }
 
-const _config = {
-  space: process.env.CF_SPACE_ID ?? '',
-  accessToken: process.env.CF_ACCESS_TOKEN ?? '',
+const prodConfig = {
+  space: process.env.CF_SPACE_ID!,
+  accessToken: process.env.CF_ACCESS_TOKEN!,
 }
 
-const config =
-  process.env.NODE_ENV === 'production'
-    ? _config
-    : {
-        ..._config,
-        // NOTE: preview の API を叩く場合は host を preview.contentful.com にする必要がある
-        //       https://www.contentful.com/developers/docs/references/content-preview-api/
-        host: 'preview.contentful.com',
-      }
+const devConfig = {
+  ...prodConfig,
+  // NOTE: preview の API を叩く場合は host を preview.contentful.com にする必要がある
+  //       https://www.contentful.com/developers/docs/references/content-preview-api/
+  host: 'preview.contentful.com',
+}
 
+const config = process.env.NODE_ENV === 'production' ? prodConfig : devConfig
+
+console.log('============================= CONFIG =============================')
+console.log(config)
 const client = createClient(config)
 
 const articlesPerPage = 12


### PR DESCRIPTION
## 実装内容
- 本番環境では publish された記事を取得する Content Delivery API を使う
- 本番以外では publish されていない記事を取得する Preview API を使う
- ついでに `ArticleContent` の Story を修正


## 関連 Issue
